### PR TITLE
feat: ignore reviewer not collaborator error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,6 @@
 import { strict as assert } from 'assert';
+import * as util from 'util';
+
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { validateConfig } from './models/config';
@@ -37,7 +39,7 @@ async function main() {
             issue_number: github.context.issue.number,
             assignees: owners,
         });
-        core.debug(JSON.stringify(addAssigneesResult));
+        core.debug(util.inspect(addAssigneesResult));
     }
 
 
@@ -74,14 +76,14 @@ async function main() {
             // Ignore the case when the owner is not a collaborator.
             // Happens in forks and when the user hasn't yet received a write bit on the repo.
             assert(err.message?.includes?.('Reviews may only be requested from collaborators'), err);
-            core.info(`Ignoring error: ${err.toString()}`);
+            core.info(`Ignoring error: ${util.inspect(err)}`);
             return err;
         });
-        core.debug(JSON.stringify(requestReviewersResult));
+        core.debug(util.inspect(requestReviewersResult));
     }
 }
 
 main().catch(err => {
-    core.debug(err.toString());
+    core.debug(util.inspect(err));
     core.setFailed(err.message);
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import { strict as assert } from 'assert';
-import * as core from "@actions/core";
-import * as github from "@actions/github";
-import { validateConfig } from "./models/config";
-import { getChangedFiles, getOwners, getPullAuthor, getRefs, getReviewers, getReviews, loadYaml } from "./utils";
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+import { validateConfig } from './models/config';
+import { getChangedFiles, getOwners, getPullAuthor, getRefs, getReviewers, getReviews, loadYaml } from './utils';
 
 async function main() {
     const client = github.getOctokit(core.getInput('repo-token', { required: true }));
@@ -27,10 +27,10 @@ async function main() {
     const changedFiles = await getChangedFiles(client, base, head);
     const owners = getOwners(config, changedFiles);
 
-    core.info(`${owners.length} owners found ${owners.join(" ")}`);
+    core.info(`${owners.length} owners found ${owners.join(' ')}`);
 
     if (assignOwners && owners.length > 0) {
-        core.info("Adding assignees");
+        core.info('Adding assignees');
         const addAssigneesResult = await client.rest.issues.addAssignees({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
@@ -42,7 +42,7 @@ async function main() {
 
 
     const reviewers = new Set<string>(owners);
-    if (reviewers.has(author) || reviewers.has(author.toLowerCase())) core.info("PR author is a component owner");
+    if (reviewers.has(author) || reviewers.has(author.toLowerCase())) core.info('PR author is a component owner');
     reviewers.delete(author);
     reviewers.delete(author.toLowerCase());
 
@@ -64,7 +64,7 @@ async function main() {
     }
 
     if (requestOwnerReviews && reviewers.size > 0) {
-        core.info("Adding reviewers");
+        core.info('Adding reviewers');
         const requestReviewersResult = await client.rest.pulls.requestReviewers({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { strict as assert } from 'assert';
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 import { validateConfig } from "./models/config";
@@ -69,6 +70,12 @@ async function main() {
             repo: github.context.repo.repo,
             pull_number: github.context.issue.number,
             reviewers: Array.from(reviewers),
+        }).catch((err) => {
+            // Ignore the case when the owner is not a collaborator.
+            // Happens in forks and when the user hasn't yet received a write bit on the repo.
+            assert(err.message?.includes?.('Reviews may only be requested from collaborators'), err);
+            core.info(`Ignoring error: ${err.toString()}`);
+            return err;
         });
         core.debug(JSON.stringify(requestReviewersResult));
     }


### PR DESCRIPTION
Mainly for ignoring the error thrown in forks and if the component owner does not have a write bit (happens in `opentelemetry-js-contrib` repo).
If anyone prefers, I'm happy to remove the other two minor updates.

### Commits

- feat: ignore the error thrown when requested reviewers not collaborators
- style: match quotes
- feat: use util.inspect instead of JSON.stringify for debugging
