### PR TITLE
Update node12 to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
GHA are being [migrated from node12 to node16](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).