### PR TITLE
feat: Output component owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Determines if the component owners should be added to the pull request as assign
 
 Determines pull request reviews should be requested from component owners.
 
+## Outputs
+
+### teams
+
+The teams which own the components which are affected by the files changed in the pr.
+The value is a comma seperated list of github group names.
+
+### users
+
+The users which own the components which are affected by the files changed in the pr.
+The value is a comma seperated list of github usernames.
+
 ## Using own access token
 
 If you want to use this action to assign reviews for teams, then `github.token` would not be sufficient and you need to generate a new one. 

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,8 @@ async function main() {
         });
         core.debug(util.inspect(requestReviewersResult));
     }
+    core.setOutput('users', [...owner_users].join(','));
+    core.setOutput('teams', [...owner_teams].join(','));
 }
 
 main().catch(err => {


### PR DESCRIPTION
Closes: #27 

This introduces 2 github outputs which contain the user owners & the team owners. The outputs are accordingly named users & teams.

By exporting them it enables us to use them in our workflows ie add a comment tagging the user's.